### PR TITLE
Make text contrast in the footer of a white theme more accessible

### DIFF
--- a/themes.js
+++ b/themes.js
@@ -5,7 +5,7 @@ const themes = [
     colors: {
       primary: '#000',
       secondary: '#fff',
-      stealthy: '#aaa',
+      stealthy: '#595959',
       invisible: '#f2f2f2',
       selectionBase: '#0064c1',
       link: '#0064c1',


### PR DESCRIPTION
Hello! I want to thank for the library. I use it for my site. During the accessibility testing, I found that the text in the footer did not meet [WCAG](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast?utm_source=devtools&utm_medium=a11y-panel-checks-color-contrast#Related_WCAG_success_criteria) contrast requirements. Picked a minimum value satisfying it. Other themes also have inconsistencies, but changes in them greatly change the colors. Therefore, I made the change only in the white theme.
![Selection_001](https://user-images.githubusercontent.com/6770140/68124170-bd821a00-ff1f-11e9-97a3-9e73f6e37a9a.png)
