### PR TITLE
Add Styling for Disabled Buttons

### DIFF
--- a/src/docs/elements.pug
+++ b/src/docs/elements.pug
@@ -284,7 +284,7 @@ include _mixins.pug
         br
 
         input(type="submit", value="Submit")
-        button(type="reset") Reset
+        button(type="reset", disabled) Reset
 
         output#output(style="display: none")
           p Welcome on board!

--- a/src/scss/awsm.scss
+++ b/src/scss/awsm.scss
@@ -511,12 +511,17 @@ legend {
   color: color('primary');
   cursor: pointer;
 
-  &:hover {
+  &:not([disabled]):hover {
     border: 1px solid color('primary');
   }
 
   &:active {
     background-color: color('stealthy');
+  }
+
+  &[disabled] {
+    color: color('stealthy');
+    cursor: not-allowed;
   }
 }
 


### PR DESCRIPTION
hi @igoradamenko 

first of all: thank you for awsm.css! it is the perfect solution for simple, nice looking html rendering without the need of any fancy, huge css library. ❤️

this pull request contains a proposal for rendering disabled `button` elements so that the user can distinguish them from enabled ones.

i added a demo to the "Misc." section of the documentation. feel free to integrate the change if you like.

cheers,
@swissmanu

ps. i was not sure if you want contributions to contain builded versions of the change... let me know if you would prefer this.